### PR TITLE
Prevent smiles display from "jumping" when displaying high numbers

### DIFF
--- a/ponyclicker.html
+++ b/ponyclicker.html
@@ -351,7 +351,7 @@
     x = Math.floor(x/Math.pow(10,d-(d%3)-3));
     var n = Math.floor((d-3)/3) - 1;
     if(n >= number_names.length) return "Infinity";
-    return (x/1000) + " " + number_names[n];
+    return (x/1000).toFixed(3) + " " + number_names[n];
   }
   function Pluralize(n, s) { return PrettyNum(n) + s + ((n==1)?'':'s'); }
   


### PR DESCRIPTION
Great job on the game! :D One thing I noticed was that the numbers display would go for instance from "1.009 million" to "1.01 million" to "1.011 million", causing the smiles display to jump around some. I fixed it so that the display goes for instance from "1.009 million" to **"1.010 million"** to "1.011 million", which makes the number display a bit easier to read because it always has the same number of digits.

Thanks for making this! I'm at 3 quintillion smiles and counting! :horse: