### PR TITLE
Improve timer accuracy

### DIFF
--- a/ponyclicker.html
+++ b/ponyclicker.html
@@ -813,7 +813,7 @@
       lastSave = timestamp;
     }
     if((timestamp - lastTick)>500) {
-      Game.totalTime += 500;
+      Game.totalTime += timestamp - lastTick;
       stat_time.innerHTML = displayTime(Game.totalTime);
       UpdateOverlay(null, null);
       lastTick = timestamp;


### PR DESCRIPTION
For #24:

By adding the full difference between ticks, the timer remains accurate even when the page is not visible or the frame rate is very low.