### PR TITLE
Inverted order of SPC calculation to allow percentage increases to ap…

### DIFF
--- a/ponyclicker.js
+++ b/ponyclicker.js
@@ -705,7 +705,7 @@ $(function(){
     var SPC = Game.SPC;
 
     Game.SPC = 1;
-    for(var i = 0; i < Game.upgrades.length; ++i) {
+    for(var i = Game.upgrades.length; i >= 0; i-=1) {
       res = upgradeList[Game.upgrades[i]].fn(res, store);
       if(!res || !res.length) {
         alert("ILLEGAL UPGRADE: " + Game.upgrades[i]);


### PR DESCRIPTION
Late game clicking does not generate a notable amount of muffins. While upgrades grant you 10% of your SPS, this is calculated without the muffin bonus, which can usually be ~300%.  Inverting the order in which the upgrades are calculated should make it so that late game, your SPC is still roughly 10%, instead of the 2-3% it ends up being.