### PR TITLE
Fix the wheel-spinning achievements

### DIFF
--- a/ponyclicker.js
+++ b/ponyclicker.js
@@ -408,8 +408,8 @@ $(function(){
     '204': { name:"Music Makes Everything Better", desc: "Listen to the smile song.", muffins:1},
     '205': { name:"You Monster", desc: "Sell a friendship.", muffins:1},
     '206': { name:"No Booping Allowed", desc: "Get <b>"+PrettyNum(1000000000000)+"</b> smiles with only 35 pony boops.", muffins:1, cond:function() { return Game.clicks <= 35 && Game.totalsmiles >= 1000000000000; } },
-    '207': { name:"Wheel of Friendship", desc: "Spin the ponies.", muffins:1, cond:function() { return vangle>0.05; } },
-    '208': { name:"Centrifuge of Friendship", desc: "Spin the ponies <b>really fast</b>.", muffins:2, cond:function() { return vangle>3; } },
+    '207': { name:"Wheel of Friendship", desc: "Spin the ponies.", muffins:1, cond:function() { return Math.abs(vangle)>0.05; } },
+    '208': { name:"Centrifuge of Friendship", desc: "Spin the ponies <b>really fast</b>.", muffins:2, cond:function() { return Math.abs(vangle)>3; } },
     '255': { name:"Completionist", desc: "Get all the achievements.", muffins:100}
   };
 

--- a/ponyclicker.js
+++ b/ponyclicker.js
@@ -1329,6 +1329,7 @@ $(function(){
   }
   var fnmouseup = function(event) {
     vangle = vlastangle;
+    CheckAchievements([207, 208]);
     mleftdown=false;
     vlastangle = 0;
   }


### PR DESCRIPTION
Whenever the user lets go of the wheel and `vangle` is set, the wheel-spinning achievements 207 and 208 should be checked.