### PR TITLE
Fix #72: Change SPC to SPB in user interface.

### DIFF
--- a/ponyclicker.js
+++ b/ponyclicker.js
@@ -379,8 +379,8 @@ $(function(){
   function gencountcond(item, count) { return function() { return Game.store[item] >= count && this.cost < (Game.totalsmiles*1.2)} }
   
   var upgradeList = [ {cost:0, name:"UNDEFINED", desc:"ERROR", fn:null},
-    {cost:600, name:"Booping Assistants", desc: "Booping gets +1 SPC for every pony you have.", fn:gen_upgradetype2(0, 1, 0), cond:defcond},
-    {cost:7000, name:"Friendship is Booping", desc: "Booping gets +1 SPC for every friendship you have.", fn:gen_upgradetype2(1, 1, 0), cond:defcond },
+    {cost:600, name:"Booping Assistants", desc: "Booping gets +1 SPB for every pony you have.", fn:gen_upgradetype2(0, 1, 0), cond:defcond},
+    {cost:7000, name:"Friendship is Booping", desc: "Booping gets +1 SPB for every friendship you have.", fn:gen_upgradetype2(1, 1, 0), cond:defcond },
     {cost:70000, name:"Ticklish Cursors", desc: "Booping gets 1% of your SPS.", fn:gen_upgradetype2(0, 0, 0.01), cond:defcond},
     {cost:700000, name:"Feathered Cursors", desc: "Booping gets an additional 2% of your SPS.", fn:gen_upgradetype2(0, 0, 0.02), cond:defcond},
     {cost:8000000, name:"Advanced Tickle-fu", desc: "Booping gets an additional 3% of your SPS.", fn:gen_upgradetype2(0, 0, 0.03), cond:defcond},


### PR DESCRIPTION
Since clicks are now boops, rename the SPC acronym in strings.
Variable names and comments remain unchanged, because they still
use "clicks".